### PR TITLE
Implement Release Management

### DIFF
--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -39,6 +39,7 @@ in {
 				nixosModules.system-lanzaboote
 				nixosModules.system-locale
 				nixosModules.system-nix
+				nixosModules.system-release
 				nixosModules.system-security
 				nixosModules.system-security-nvidia
 				nixosModules.system-time

--- a/src/nixos/machines/mracek/config/hardware-configuration.nix
+++ b/src/nixos/machines/mracek/config/hardware-configuration.nix
@@ -10,8 +10,6 @@ let
 in {
 	networking.hostName = "mracek";
 
-	system.stateVersion = "24.05";
-
 	services.logind.lidSwitchExternalPower = "lock"; # Lock the system on closing the lid when on external power instead of suspend/hibernation
 
 	# BootLoader

--- a/src/nixos/machines/sinnenfreude/config/hardware-configuration.nix
+++ b/src/nixos/machines/sinnenfreude/config/hardware-configuration.nix
@@ -10,8 +10,6 @@ let
 in {
 	networking.hostName = "sinnenfreude";
 
-	system.stateVersion = "24.05";
-
 	# BootLoader
 	## NOTE(Krey): Has a weird BIOS, lanzaboote has issues with deployment
 	boot.loader.systemd-boot.enable = true; # Lanzeboote uses it's own module and requires this disabled

--- a/src/nixos/modules/system/default.nix
+++ b/src/nixos/modules/system/default.nix
@@ -10,6 +10,7 @@
 		./lanzaboote
 		./locale
 		./nix
+		./release
 		./security
 		./time
 		./wifi

--- a/src/nixos/modules/system/release/default.nix
+++ b/src/nixos/modules/system/release/default.nix
@@ -1,0 +1,3 @@
+{
+	flake.nixosModules.system-release = ./locale.nix;
+}

--- a/src/nixos/modules/system/release/release.nix
+++ b/src/nixos/modules/system/release/release.nix
@@ -1,0 +1,10 @@
+{ self, config, lib, ...}:
+
+# Global Release Management Module
+
+let
+	inherit (lib) mkIf;
+in {
+	# Impermanent setup does not have state
+	system.stateVersion = mkIf config.boot.impermanence.enable config.system.nixos.release;
+}


### PR DESCRIPTION
Currently all systems need to have `system.stateVersion` set which is bloat and as the releases go are putting stress on maintanance, so this is trying to manage it assuming impermanent setup.