### PR TITLE
Kreyren: Attempt to Fix Flameshot

### DIFF
--- a/src/nixos/users/kreyren/home/machines/sinnenfreude/home-configuration.nix
+++ b/src/nixos/users/kreyren/home/machines/sinnenfreude/home-configuration.nix
@@ -22,6 +22,7 @@
 	programs.nix-index.enable = true;
 
 	services.gpg-agent.enable = true;
+	services.flameshot.enable = true;
 
 	nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
 		# FIXME(Krey): Using vscodium, no idea why this needs 'vscode' set

--- a/src/nixos/users/kreyren/home/modules/system/dconf/dconf.nix
+++ b/src/nixos/users/kreyren/home/modules/system/dconf/dconf.nix
@@ -3,7 +3,6 @@
 let
 	inherit (lib) mkForce;
 	inherit (lib.hm.gvariant) mkTuple;
-  flameshot-gui = pkgs.writeShellScriptBin "flameshot-gui" "${pkgs.flameshot}/bin/flameshot gui";
 in {
 	# Use `$ dconf dump /` to get these
 	# dconf2nix, can be used to make this process easier -- https://github.com/gvolpe/dconf2nix
@@ -121,8 +120,8 @@ in {
 		## Flameshot GUI
 		"org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4" = {
 			name = "Flameshot GUI";
-			command = "${flameshot-gui}/bin/flameshot-gui";
-			binding = "Print";
+			command = "flameshot gui";
+			binding = "<Control>Print";
 		};
 
 		# Background


### PR DESCRIPTION
Flameshot doesn't work on GNOME with Wayland for me.

```
...
reloading user units for kreyren...
restarting sysinit-reactivation.target
warning: the following units failed: home-manager-kreyren.service

× home-manager-kreyren.service - Home Manager environment for kreyren
     Loaded: loaded (/etc/systemd/system/home-manager-kreyren.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Mon 2024-07-08 23:38:57 UTC; 80ms ago
   Duration: 1min 34.328s
    Process: 226322 ExecStart=/nix/store/7i0d80cp7l2f3kzphp2pgl75f8k9bqal-hm-setup-env /nix/store/0nfh4hiibnj1zy7jj4paklrdzk3f33lk-home-manager-generation (code=exited, status=1/FAILURE)
   Main PID: 226322 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
        CPU: 1.138s

Jul 08 23:38:56 sinnenfreude hm-activate-kreyren[226322]: Creating home file links in /home/kreyren
Jul 08 23:38:56 sinnenfreude hm-activate-kreyren[226322]: Activating onFilesChange
Jul 08 23:38:56 sinnenfreude hm-activate-kreyren[226322]: Activating runUnmountPersistentStoragePaths
Jul 08 23:38:56 sinnenfreude hm-activate-kreyren[226322]: Activating reloadSystemd
Jul 08 23:38:57 sinnenfreude hm-activate-kreyren[227021]: Starting: flathub-init.service flameshot.service
Jul 08 23:38:57 sinnenfreude hm-activate-kreyren[227021]: Failed to start flameshot.service: Unit tray.target not found.
Jul 08 23:38:57 sinnenfreude systemd[1]: home-manager-kreyren.service: Main process exited, code=exited, status=1/FAILURE
Jul 08 23:38:57 sinnenfreude systemd[1]: home-manager-kreyren.service: Failed with result 'exit-code'.
Jul 08 23:38:57 sinnenfreude systemd[1]: Failed to start Home Manager environment for kreyren.
Jul 08 23:38:57 sinnenfreude systemd[1]: home-manager-kreyren.service: Consumed 1.138s CPU time, no IP traffic.
warning: error(s) occurred while switching to the new configuration
```

Relevant: https://github.com/NixOS/nixpkgs/issues/292700#issuecomment-1974953531
Relevant: https://github.com/nix-community/home-manager/issues/2064