### PR TITLE
machines: tempSize 5->10G + QoL

### DIFF
--- a/src/nixos/machines/flexy/config/disks.nix
+++ b/src/nixos/machines/flexy/config/disks.nix
@@ -2,19 +2,20 @@
 
 # Nix-based Disk Management of FLEXY with disko and impermenance on tmpfs
 
-# Formatting strategy:
-#    Table: GPT
-#    2048 - 1050623 (1048576) -- 512M EFI System
-#    1050624 - 479145983 (478095360) -- -10G nix store BTRFS
-#    479145984 - 500117503 (20971520) -- 100% Encrypted swap
-
 let
 	inherit (lib) mkMerge;
-
 	diskoDevice = "/dev/disk/by-id/nvme-UMIS_RPJTJ256MEE1OWX_SS0W76181Z1CD11J23ED";
+	swapSize = "10G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G";
 in mkMerge [
 	{
 		age.secrets.flexy-disks-password.file = ../secrets/flexy-disks-password.age; # Supply password for disk encryption
+
+		age.secrets.flexy-unlock-key.file = ../secrets/flexy-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -29,7 +30,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=1G"
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -39,7 +40,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					# imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -88,10 +89,19 @@ in mkMerge [
 												mountpoint = "/nix";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
-											"@persist" = {
+											"@system-persist" = {
 												mountpoint = "/nix/persist/system";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											# FIXME(Krey): Causes emergency shell
+											# "@nixium-persist" = {
+											#  	mountpoint = "/nix/persist/NiXium";
+											# 	mountOptions = [ "compress=lzo" "noatime" ];
+											# };
 										};
 									};
 								};
@@ -99,7 +109,7 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "10G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -142,7 +152,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				# imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -183,22 +193,26 @@ in mkMerge [
 									type = "btrfs";
 									extraArgs = [ "--label NIX_STORE" ];
 									subvolumes = {
-										"@nix" = {
-											mountpoint = "/nix";
-											mountOptions = [ "compress=lzo" "noatime" ];
+											"@nix" = {
+												mountpoint = "/nix";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@system-persist" = {
+												mountpoint = "/nix/persist/system";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
 										};
-										"@persist" = {
-											mountpoint = "/nix/persist/system";
-											mountOptions = [ "compress=lzo" "noatime" ];
-										};
-									};
 								};
 							};
 						};
 
 						swap = {
 							priority = 2;
-							size = "10G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";

--- a/src/nixos/machines/ignucius/config/disks.nix
+++ b/src/nixos/machines/ignucius/config/disks.nix
@@ -21,9 +21,18 @@ let
 	inherit (lib) mkMerge;
 
 	diskoDevice = "/dev/disk/by-id/ata-CT500MX500SSD1_21052CD42FFF";
+	swapSize = "30G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G"; # Size of Image for VM
+
 in mkMerge [
 	{
 		age.secrets.ignucius-disks-password.file = ../secrets/ignucius-disks-password.age; # Supply password for disk encryption
+
+		# age.secrets.ignucius-unlock-key.file = ../secrets/ignucius-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		# boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -38,7 +47,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=5G" # >=5GB Needed to avoid no space left errors during rebuilds
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -48,7 +57,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -117,7 +126,7 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "30G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -160,7 +169,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -220,7 +229,7 @@ in mkMerge [
 
 						swap = {
 							priority = 2;
-							size = "30G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";

--- a/src/nixos/machines/lengo/config/disks.nix
+++ b/src/nixos/machines/lengo/config/disks.nix
@@ -2,21 +2,16 @@
 
 # Nix-based Disk Management of LENGO with disko and impermenance on tmpfs
 
-# Formatting strategy:
-#    Table: GPT
-#    2048 - 1050623 (1048576) -- 512M EFI System
-#    1050624 - 937291775 (936241152) -- -30G nix store BTRFS
-#    937291776 - 1000206866 (62915091) -- 100% Encrypted swap
-
 # Reference: https://github.com/ryan4yin/nix-config/blob/82dccbdecaf73835153a6470c1792d397d2881fa/hosts/12kingdoms-suzu/disko-fs.nix#L21
 
 # Reference: https://github.com/lilyinstarlight/foosteros/blob/ccaca3910a61ee790f9cfd000cf77074524676b8/hosts/minimal/disks.nix#L4
 
 let
 	inherit (lib) mkMerge;
-
 	diskoDevice = "/dev/disk/by-id/nvme-WD_PC_SN740_SDDPMQD-512G-1101_2335R1406872";
 	swapSize = "60G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G";
 in mkMerge [
 	{
 		age.secrets.lengo-disks-password.file = ../secrets/lengo-disks-password.age; # Supply password for disk encryption
@@ -25,14 +20,6 @@ in mkMerge [
 
 		# Needed to find the SD Card device during initrd stage
 		boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
-	}
-
-	# FIXME(Krey): Causes infinite recursion, no idea why
-	# (if (config.boot.impermenance.enable == true) then {
-	(if (true) then {
-		age.identityPaths = [ "/nix/persist/system/etc/ssh/ssh_host_ed25519_key" ]; # Change the identity path to use our disko path
-
-		fileSystems."/nix/persist/system".neededForBoot = true;
 
 		boot.initrd.luks.devices = {
 			swap = {
@@ -52,13 +39,22 @@ in mkMerge [
 				# fallbackToPassword = true;
 			};
 		};
+	}
+
+	# FIXME(Krey): Causes infinite recursion, no idea why
+	# (if (config.boot.impermenance.enable == true) then {
+	(if (true) then {
+		age.identityPaths = [ "/nix/persist/system/etc/ssh/ssh_host_ed25519_key" ]; # Change the identity path to use our disko path
+
+		fileSystems."/nix/persist/system".neededForBoot = true;
+
 
 		# FIXME(Krey): Figure out how to do labels
 		disko.devices = {
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=5G" # >=5GB Needed to avoid no space left errors during rebuilds
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -68,7 +64,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -97,8 +93,6 @@ in mkMerge [
 									settings.allowDiscards = true;
 
 									passwordFile = config.age.secrets.lengo-disks-password.path;
-
-									keyFile = "/dev/disk/by-id/mmc-SA02G_0x9cdde6c0";
 
 									initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 
@@ -137,10 +131,9 @@ in mkMerge [
 								};
 							};
 
-							# FIXME(Krey): This partition should be last to make it easier to make on-fly adjustments to it
 							swap = {
 								priority = 2;
-								size = swapSize;
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -148,8 +141,6 @@ in mkMerge [
 									settings.allowDiscards = true;
 
 									passwordFile = config.age.secrets.lengo-disks-password.path;
-
-									keyFile = "/dev/disk/by-id/mmc-SA02G_0x9cdde6c0";
 
 									initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 
@@ -163,6 +154,7 @@ in mkMerge [
 									];
 
 									content = {
+										# FIXME-QA(Krey): Add label 'SWAP'
 										type = "swap";
 										resumeDevice = true; # resume from hiberation from this device
 
@@ -209,7 +201,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -269,7 +261,7 @@ in mkMerge [
 
 						swap = {
 							priority = 2;
-							size = "30G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";

--- a/src/nixos/machines/morph/config/disks.nix
+++ b/src/nixos/machines/morph/config/disks.nix
@@ -18,9 +18,17 @@ let
 	inherit (lib) mkMerge;
 
 	diskoDevice = "/dev/disk/by-id/ata-Micron_M600_MTFDDAK256MBF_14380F0D8268";
+	swapSize = "20G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G"; # Size of Image for VM
 in mkMerge [
 	{
 		age.secrets.morph-disks-password.file = ../secrets/morph-disks-password.age; # Supply password for disk encryption
+
+		# age.secrets.morph-unlock-key.file = ../secrets/morph-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		# boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -35,7 +43,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=5G"
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -45,7 +53,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					# imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -94,10 +102,19 @@ in mkMerge [
 												mountpoint = "/nix";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
-											"@persist" = {
+											"@system-persist" = {
 												mountpoint = "/nix/persist/system";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											# FIXME(Krey): Causes emergency shell
+											# "@nixium-persist" = {
+											#  	mountpoint = "/nix/persist/NiXium";
+											# 	mountOptions = [ "compress=lzo" "noatime" ];
+											# };
 										};
 									};
 								};
@@ -105,7 +122,7 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "20G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -148,7 +165,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				# imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -189,22 +206,26 @@ in mkMerge [
 									type = "btrfs";
 									extraArgs = [ "--label NIX_STORE" ];
 									subvolumes = {
-										"@nix" = {
-											mountpoint = "/nix";
-											mountOptions = [ "compress=lzo" "noatime" ];
+											"@nix" = {
+												mountpoint = "/nix";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@system-persist" = {
+												mountpoint = "/nix/persist/system";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
 										};
-										"@persist" = {
-											mountpoint = "/nix/persist/system";
-											mountOptions = [ "compress=lzo" "noatime" ];
-										};
-									};
 								};
 							};
 						};
 
 						swap = {
 							priority = 2;
-							size = "20G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";
@@ -225,6 +246,7 @@ in mkMerge [
 								];
 
 								content = {
+									# FIXME-QA(Krey): Add label 'SWAP'
 									type = "swap";
 									resumeDevice = true; # resume from hiberation from this device
 

--- a/src/nixos/machines/mracek/config/disks.nix
+++ b/src/nixos/machines/mracek/config/disks.nix
@@ -21,9 +21,18 @@ let
 	inherit (lib) mkMerge;
 
 	diskoDevice = "/dev/disk/by-id/ata-WDC_WDS500G2B0A-00SM50_21101J456803";
+	swapSize = "30G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G"; # Size of Image for VM
+
 in mkMerge [
 	{
 		age.secrets.mracek-disks-password.file = ../secrets/mracek-disks-password.age; # Supply password for disk encryption
+
+		# age.secrets.mracek-unlock-key.file = ../secrets/mracek-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		# boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -38,7 +47,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=1G"
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -48,7 +57,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -60,6 +69,10 @@ in mkMerge [
 								content = {
 									type = "filesystem";
 									format = "vfat"; # FAT32
+									# SECURITY(Krey): Required since systemd 254, to not make the random-seed file writtable by default
+									# * https://github.com/nix-community/disko/issues/527#issuecomment-1924076948
+									# * https://discourse.nixos.org/t/nixos-install-with-custom-flake-results-in-boot-being-world-accessible/34555/14
+									mountOptions = [ "umask=0077" ];
 									mountpoint = "/boot";
 								};
 							};
@@ -93,10 +106,19 @@ in mkMerge [
 												mountpoint = "/nix";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
-											"@persist" = {
+											"@system-persist" = {
 												mountpoint = "/nix/persist/system";
 												mountOptions = [ "compress=lzo" "noatime" ];
 											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											# FIXME(Krey): Causes emergency shell
+											# "@nixium-persist" = {
+											#  	mountpoint = "/nix/persist/NiXium";
+											# 	mountOptions = [ "compress=lzo" "noatime" ];
+											# };
 										};
 									};
 								};
@@ -104,7 +126,7 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "30G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -147,7 +169,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -188,22 +210,26 @@ in mkMerge [
 									type = "btrfs";
 									extraArgs = [ "--label NIX_STORE" ];
 									subvolumes = {
-										"@nix" = {
-											mountpoint = "/nix";
-											mountOptions = [ "compress=lzo" "noatime" ];
+											"@nix" = {
+												mountpoint = "/nix";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@system-persist" = {
+												mountpoint = "/nix/persist/system";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
+											"@user-persist" = {
+												mountpoint = "/nix/persist/users";
+												mountOptions = [ "compress=lzo" "noatime" ];
+											};
 										};
-										"@persist" = {
-											mountpoint = "/nix/persist/system";
-											mountOptions = [ "compress=lzo" "noatime" ];
-										};
-									};
 								};
 							};
 						};
 
 						swap = {
 							priority = 2;
-							size = "30G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";

--- a/src/nixos/machines/sinnenfreude/config/disks.nix
+++ b/src/nixos/machines/sinnenfreude/config/disks.nix
@@ -21,9 +21,18 @@ let
 	inherit (lib) mkMerge;
 
 	diskoDevice = "/dev/disk/by-id/ata-CT500MX500SSD1_21052CD42FFF";
+	swapSize = "30G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G"; # Size of Image for VM
+
 in mkMerge [
 	{
 		age.secrets.sinnenfreude-disks-password.file = ../secrets/sinnenfreude-disks-password.age; # Supply password for disk encryption
+
+		# age.secrets.sinnenfreude-unlock-key.file = ../secrets/sinnenfreude-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		# boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -38,7 +47,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=5G" # >=5GB Needed to avoid no space left errors during rebuilds
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -48,7 +57,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -117,7 +126,7 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "30G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
@@ -160,7 +169,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -220,7 +229,7 @@ in mkMerge [
 
 						swap = {
 							priority = 2;
-							size = "30G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";

--- a/src/nixos/machines/template/config/disks.nix
+++ b/src/nixos/machines/template/config/disks.nix
@@ -2,12 +2,6 @@
 
 # Nix-based Disk Management of TEMPLATE with disko and impermenance on tmpfs
 
-# Formatting strategy:
-#    Table: GPT
-#    2048 - 1050623 (1048576) -- 512M EFI System
-#    1050624 - 913858559 (912807936) -- -30G nix store BTRFS
-#    913858560 - 976773119 (62914560) -- 100% Encrypted swap
-
 # Reference: https://github.com/ryan4yin/nix-config/blob/82dccbdecaf73835153a6470c1792d397d2881fa/hosts/12kingdoms-suzu/disko-fs.nix#L21
 
 # Reference: https://github.com/lilyinstarlight/foosteros/blob/ccaca3910a61ee790f9cfd000cf77074524676b8/hosts/minimal/disks.nix#L4
@@ -15,10 +9,19 @@
 let
 	inherit (lib) mkMerge;
 
-	diskoDevice = "/dev/disk/by-id/ata-CT500MX500SSD1_21052CD42FFF";
+	diskoDevice = "/dev/disk/by-id/DEVICE";
+	swapSize = "60G";
+	tempSize = "10G"; # >=10GB Needed to avoid no space left errors during rebuilds
+	imageSize = "50G"; # Size of Image for VM
+
 in mkMerge [
 	{
-		age.secrets.template-disks-password.file = ../secrets/template-disks-password.age; # Supply password for disk encryption
+		age.secrets.TEMPLATE-disks-password.file = ../secrets/TEMPLATE-disks-password.age; # Supply password for disk encryption
+
+		age.secrets.TEMPLATE-unlock-key.file = ../secrets/TEMPLATE-unlock-key.age; # KeyFile for unlocking the filesystems
+
+		# Needed to find the SD Card device during initrd stage
+		boot.initrd.kernelModules = [ "mmc_core" "mmc_block" "sd_mod"  ];
 	}
 
 	# FIXME(Krey): Causes infinite recursion, no idea why
@@ -33,7 +36,7 @@ in mkMerge [
 			nodev."/" = {
 				fsType = "tmpfs";
 				mountOptions = [
-					"size=5G" # >=5GB Needed to avoid no space left errors during rebuilds
+					"size=${tempSize}"
 					"defaults"
 					"mode=755"
 				];
@@ -43,7 +46,7 @@ in mkMerge [
 				system = {
 					device = diskoDevice;
 					type = "disk";
-					imageSize = "50G"; # Size of the generated image
+					imageSize = "${imageSize}"; # Size of the generated image
 					content = {
 						type = "gpt";
 						partitions = {
@@ -71,7 +74,7 @@ in mkMerge [
 									type = "luks";
 									settings.allowDiscards = true;
 
-									passwordFile = config.age.secrets.template-disks-password.path;
+									passwordFile = config.age.secrets.TEMPLATE-disks-password.path;
 
 									initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 
@@ -112,14 +115,14 @@ in mkMerge [
 
 							swap = {
 								priority = 2;
-								size = "30G";
+								size = "${swapSize}";
 								content = {
 									name = "swap";
 									type = "luks";
 
 									settings.allowDiscards = true;
 
-									passwordFile = config.age.secrets.template-disks-password.path;
+									passwordFile = config.age.secrets.TEMPLATE-disks-password.path;
 
 									initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 
@@ -155,7 +158,7 @@ in mkMerge [
 			system = {
 				device = diskoDevice;
 				type = "disk";
-				imageSize = "50G"; # Size of the generated image
+				imageSize = "${imageSize}"; # Size of the generated image
 				content = {
 					type = "gpt";
 					partitions = {
@@ -179,7 +182,7 @@ in mkMerge [
 								type = "luks";
 								settings.allowDiscards = true;
 
-								passwordFile = config.age.secrets.template-disks-password.path;
+								passwordFile = config.age.secrets.TEMPLATE-disks-password.path;
 
 								initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 
@@ -215,14 +218,14 @@ in mkMerge [
 
 						swap = {
 							priority = 2;
-							size = "30G";
+							size = "${swapSize}";
 							content = {
 								name = "swap";
 								type = "luks";
 
 								settings.allowDiscards = true;
 
-								passwordFile = config.age.secrets.template-disks-password.path;
+								passwordFile = config.age.secrets.TEMPLATE-disks-password.path;
 
 								initrdUnlock = true; # Add a boot.initrd.luks.devices entry for the specified disk
 


### PR DESCRIPTION
* As observed on LENGO it's no longer enough to have just 5GB of temporary storage thus increased on 10G
* Quality of Life Improvements through let variables enabling easy configuration
* Refreshed all machines from template